### PR TITLE
UI&UX improvement suggestions

### DIFF
--- a/sidebar/panel.css
+++ b/sidebar/panel.css
@@ -62,6 +62,7 @@ progress{
 
 .textInput #currentMark {
   width: 99%;
+  padding-right: 30px;
 }
 
 .importExportWindow {

--- a/sidebar/panel.css
+++ b/sidebar/panel.css
@@ -35,6 +35,7 @@ button{
   background-color: transparent;
   border: 1px solid #9e9e9e;
   border-radius: 8px;
+  margin-top: 10px;
 }
 
 #markings {
@@ -53,4 +54,43 @@ progress{
 
 .dimmed{
   color: rgba(255, 255, 255, 0.5)
+}
+.textInput * {
+  position: relative;
+  float: left;
+}
+
+.textInput #currentMark {
+  width: 99%;
+}
+
+.importExportWindow {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.2s ease-out;
+}
+
+.importExportWindow.active {
+  max-height: 40px;
+}
+
+#dropdownData>p {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  text-align: center;
+  top: 1px;
+  right: 5px;
+  border: 2px solid darkgrey;
+  border-radius: 4px;
+  color: black;
+  background-color: white;
+  rotate: 90deg;
+  transition: transform 0.2s ease-out;
+  z-index: 2;
+}
+
+#dropdownData.active>p {
+  background-color: darkgrey;
+  transform: rotate(-90deg) scale(0.8);
 }

--- a/sidebar/panel.html
+++ b/sidebar/panel.html
@@ -11,9 +11,9 @@
     <input id="importNotes" type="file" hidden />
     <input type="text" id="currentMark" placeholder="Type your notes here:" />
     <div>
-      <button id="exportBtn">Export</button>
-      <button id="importBtn">Import</button>
-      <button id="copyBtn">Copy</button>
+      <button id="exportBtn" title="Export all notes to a file">Export</button>
+      <button id="importBtn" title="Import notes from file (global)">Import</button>
+      <button id="copyBtn" title="Copy notes to this video from another video">Copy</button>
     </div>
     <ul id="markings"></ul>
     <script src="panel.js"></script>

--- a/sidebar/panel.html
+++ b/sidebar/panel.html
@@ -6,16 +6,22 @@
     <link rel="stylesheet" href="panel.css" />
   </head>
 
-  <body>
-    <div id="progressContainer"></div>
-    <input id="importNotes" type="file" hidden />
+
+<body>
+  <div id="progressContainer"></div>
+  <input id="importNotes" type="file" hidden />
+  <div class="textInput">
     <input type="text" id="currentMark" placeholder="Type your notes here:" />
-    <div>
+    <div id="dropdownData">
+      <p>&#9947</p>
+    </div>
+    <div class="importExportWindow">
       <button id="exportBtn" title="Export all notes to a file">Export</button>
       <button id="importBtn" title="Import notes from file (global)">Import</button>
       <button id="copyBtn" title="Copy notes to this video from another video">Copy</button>
     </div>
-    <ul id="markings"></ul>
-    <script src="panel.js"></script>
-  </body>
+  </div>
+  <ul id="markings"></ul>
+  <script src="panel.js"></script>
+</body>
 </html>

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -320,7 +320,7 @@ function updateMarkingsHtml() {
     }
   });
   progressHtml.setAttribute("value", learnedNotes);
-  //progressContainer.appendChild(progressHtml);
+  progressContainer.appendChild(progressHtml);
   markingsHtml.innerHTML = "";
   markings.forEach((marking) => {
     const markingHtml = createMarking(

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -39,13 +39,25 @@ exportBtn.addEventListener("mousedown", (event) => {
 importBtn.addEventListener("mousedown", (event) => {
   importNotes.click();
 });
-copyBtn.addEventListener("mousedown", async (event) => {
-  let id = currentMarkingHtml.value;
+
+copyBtn.addEventListener("mousedown", async () => {
+  let id = prompt(
+    "Enter the id of the source you wish to copy notes from.\n" +
+    "(Example: dQw4w9WgXcQ is the id of the video url below)\n" +
+    "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    "dQw4w9WgXcQ"
+  )
+  if (!id) return;
+
   let storedInfo = await browser.storage.local.get(id);
-  if (!storedInfo[Object.keys(storedInfo)[0]]) return;
+  if (!storedInfo[Object.keys(storedInfo)[0]]) {
+    alert(`Couldn't find any notes for id "${id}"`);
+    return;
+  };
   let shouldCopy = confirm(
+    "THIS WILL OVERWRITE THE NOTES FOR THIS VIDEO!!\n\n" +
     "Are you sure you want to copy: " +
-      storedInfo[Object.keys(storedInfo)[0]].slice(0, 2000)
+    storedInfo[Object.keys(storedInfo)[0]].slice(0, 2000)
   );
   if (!shouldCopy) return;
   markingsHtml.innerHTML = "";

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -24,6 +24,7 @@ importNotes.addEventListener("change", (event) => {
       browser.storage.local.set(importJson);
     };
   }
+  location.reload();
 });
 
 exportBtn.addEventListener("mousedown", (event) => {
@@ -36,8 +37,12 @@ exportBtn.addEventListener("mousedown", (event) => {
     dlAnchorElem.click();
   });
 });
-importBtn.addEventListener("mousedown", (event) => {
-  importNotes.click();
+
+importBtn.addEventListener("mousedown", () => {
+  let confirmStatue = confirm("Current notes will get OVERWRITTEN by the content of the file.\nDo you want to continue?")
+  if (confirmStatue === true) {
+    importNotes.click();
+  }
 });
 
 copyBtn.addEventListener("mousedown", async () => {
@@ -79,7 +84,7 @@ markingsHtml.addEventListener("mousedown", (event) => {
           if (!shouldDelete) return;
           markings = markings.filter((marking) => marking.id != markingId);
         } else if (event.shiftKey) {
-          let newTitle = prompt("New title for: " + marking.title);
+          let newTitle = prompt("New title for: " + marking.title, marking.title);
           if (newTitle) {
             marking.title = newTitle;
           }

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -69,15 +69,15 @@ copyBtn.addEventListener("mousedown", async () => {
 
 markingsHtml.addEventListener("mousedown", (event) => {
   if (event.which === 1 && event.target.classList.contains("title")) {
-    let time = parseFloat(event.target.dataset.time);
+    let markingId = parseFloat(event.target.dataset.id);
     markings.forEach((marking) => {
-      if (marking.time == time) {
+      if (marking.id == markingId) {
         if (event.ctrlKey) {
           let shouldDelete = confirm(
             "Are you sure you want to delete: " + marking.title
           );
           if (!shouldDelete) return;
-          markings = markings.filter((marking) => marking.time != time);
+          markings = markings.filter((marking) => marking.id != markingId);
         } else if (event.shiftKey) {
           let newTitle = prompt("New title for: " + marking.title);
           if (newTitle) {
@@ -99,9 +99,9 @@ markingsHtml.addEventListener("mousedown", (event) => {
     event.preventDefault();
     event.target.checked = !event.target.checked;
     let canExplain = event.target.checked;
-    let time = parseFloat(event.target.dataset.time);
+    let markingId = parseFloat(event.target.dataset.id);
     markings.forEach((marking) => {
-      if (marking.time == time) {
+      if (marking.id == markingId) {
         marking.canExplain = canExplain;
       }
     });
@@ -153,6 +153,7 @@ currentMarkingHtml.addEventListener("keyup", async (event) => {
       canExplain: false,
       title: currentMarkingHtml.value,
       time: timeStartWritingMarking,
+      id: markings.length
     });
     markings.sort(function (x, y) {
       if (x.time > y.time) {
@@ -215,12 +216,13 @@ function setVideoTime(seconds) {
   });
 }
 
-function createMarking(value, seconds, canExplain) {
+function createMarking(value, seconds, canExplain, id) {
   var checkbox = document.createElement("INPUT");
   checkbox.checked = canExplain;
   checkbox.setAttribute("type", "checkbox");
   checkbox.className = "canExplainCheckbox";
   checkbox.dataset.time = seconds;
+  checkbox.dataset.id = id;
   const marking = document.createElement("li");
   const time = document.createElement("p");
   time.className = "time";
@@ -236,6 +238,7 @@ function createMarking(value, seconds, canExplain) {
   }
   title.innerText = value;
   title.dataset.time = seconds;
+  title.dataset.id = id
   marking.appendChild(checkbox);
   marking.appendChild(time);
   marking.appendChild(title);
@@ -310,7 +313,8 @@ function updateMarkingsHtml() {
     const markingHtml = createMarking(
       marking.title,
       marking.time,
-      marking.canExplain
+      marking.canExplain,
+      marking.id
     );
     markingsHtml.appendChild(markingHtml);
   });

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -6,6 +6,8 @@ const importNotes = document.querySelector("#importNotes");
 const exportBtn = document.querySelector("#exportBtn");
 const importBtn = document.querySelector("#importBtn");
 const copyBtn = document.querySelector("#copyBtn");
+const dropdownHtml = document.getElementById('dropdownData');
+const exportWindow = document.getElementsByClassName('importExportWindow')[0];
 let markings = [];
 let previousInputLength = 0;
 const INVALID_START_TIME = -1;
@@ -14,6 +16,12 @@ let currentVideoTime;
 
 let previousTabId;
 let previousVideoId;
+
+dropdownHtml.addEventListener("mousedown", () => {
+  let visibilityClass = 'active';
+  exportWindow.classList.toggle(visibilityClass);
+  dropdownHtml.classList.toggle(visibilityClass);
+});
 
 importNotes.addEventListener("change", (event) => {
   if (importNotes.files.length == 1) {


### PR DESCRIPTION
# **This PR contains:**

1. A more usable UI by informing the user of what is happening at every step.
2. A fix for unintended CRUD operations.
	All markings on the same timestamp were treated as a single item.
3. Added a drop-down animation for the buttons to avoid accidentally clicking on them when selecting the text field.
4. When a user edits a note, the content of the current note is now displayed as a placeholder in the prompt.
5. Make the progress bar visible again.

##  **Suggestions**
### Firefox add-on store
Maybe include a link to this git repo in the description on the firefox add-on store. It makes the plugin feel more trustworthy and makes it easier for people to contribute. ;)
### Design
- For the edit feature, maybe instead of opening a prompt for the user, the marking gets edited in-place just like a textbox.
- Inform the user of shortcuts. Not that many people read the description of a firefox plugin. Maybe place a question mark next to the dropdown arrow or create a separate button?
- When the user closes the sidebar for the first time, inform the user how they can open it again. I for one, don't have the "file|edit|view" displayed by default. This might be confusing for some users.
	In addition to opening the plugin with view->sidebar->.. maybe consider supporting openingi the plugin by going to Plugins and then clicking on the plugin. Or set a global shortcut.

Please let me know if you want anything changed on my part.

Love your work, continue doing what you're doing!
